### PR TITLE
Plugin Finder: Uninstall existing files before updating

### DIFF
--- a/src/pluginfinder/modules/pluginfinder_installer.py
+++ b/src/pluginfinder/modules/pluginfinder_installer.py
@@ -141,49 +141,32 @@ class PluginFinderInstaller():
     def installedPlugins(self):
         return self.getInstalledFiles().keys()
 
-    def uninstallPlugin(self, pluginId=str):
+    def uninstallPlugin(self, pluginId: str, keepData: bool = False) -> None:
         """ Removes a plugin. """
         files = self.getInstalledFiles()
+        pluginFiles = files[str(pluginId)]
 
-        for path in files[str(pluginId)]["PluginFiles"]:
-            deletePath = self.paths.modOrganizerPluginPath() / path
-            if deletePath.exists():
-                qInfo("Deleting " + str(deletePath))
-                try:
-                    if os.path.isfile(str(deletePath)):
-                        self.utilities.deletePath(str(deletePath))
-                    if os.path.isdir(str(deletePath)):
-                        shutil.rmtree(str(deletePath))
-                except:
-                    qInfo("Could not delete " + str(deletePath))
-
-        for path in files[str(pluginId)]["LocaleFiles"]:
-            deletePath = self.paths.modOrganizerLocalePath() / path
-            if deletePath.exists():
-                qInfo("Deleting " + str(deletePath))
-                try:
-                    if os.path.isfile(str(deletePath)):
-                        self.utilities.deletePath(str(deletePath))
-                    if os.path.isdir(str(deletePath)):
-                        shutil.rmtree(str(deletePath))
-                except:
-                    qInfo("Could not delete " + str(deletePath))
-
-        for path in files[str(pluginId)]["DataFiles"]:
-            deletePath = self.paths.modOrganizerPluginPath() / path
-            if deletePath.exists():
-                qInfo("Deleting " + str(deletePath))
-                try:
-                    if os.path.isfile(str(deletePath)):
-                        self.utilities.deletePath(str(deletePath))
-                    if os.path.isdir(str(deletePath)):
-                        shutil.rmtree(str(deletePath))
-                except:
-                    qInfo("Could not delete " + str(deletePath))
+        self._deleteFiles(pluginFiles["PluginFiles"])
+        self._deleteFiles(pluginFiles["LocaleFiles"])
+        if not keepData:
+            self._deleteFiles(pluginFiles["DataFiles"])
 
         files.pop(str(pluginId))
         if pluginId != "pluginfinder":
             self.saveInstalledFiles(files)
+			
+    def _deleteFiles(self, files: list[str]) -> None:
+        for path in files:
+            deletePath = self.paths.modOrganizerPluginPath() / path
+            if deletePath.exists():
+                qInfo(f"Deleting {deletePath}")
+            try:
+                if deletePath.is_file():
+                    self.utilities.deletePath(deletePath)
+                elif deletePath.is_dir():
+                    shutil.rmtree(str(deletePath))
+            except:
+                qInfo(f"Could not delete {deletePath}")
         
     #_versionRegex = r"VersionInfo\(\s*([0-9]*)\s*,?\s*([0-9]*)\s*,?\s*([0-9]*)\s*,?\s*([0-9]*)\s*,?\s*([A-Za-z.]*)\s*\)"
     #def getPluginVersion(self, filePath=str):

--- a/src/pluginfinder/pluginfinder.py
+++ b/src/pluginfinder/pluginfinder.py
@@ -35,7 +35,11 @@ class PluginFinder():
         
     def install(self, pluginId=str):
         """ Installs the latest available version of a plugin. """
-        qInfo("Installing " + pluginId)
+        if self.installer.isInstalled(pluginId):
+            qInfo(f"Updating {pluginId}")
+            self.installer.uninstallPlugin(pluginId, keepData=True)
+        else:
+            qInfo("Installing " + pluginId)
         pluginData = self.search.pluginData(pluginId)
         self.installer.installPlugin(pluginData)
 

--- a/src/pluginfinder/pluginfinder_plugin.py
+++ b/src/pluginfinder/pluginfinder_plugin.py
@@ -5,7 +5,7 @@ from .pluginfinder import PluginFinder
 class PluginFinderPlugin(SharedPlugin):
 
     def __init__(self):
-        super().__init__("PluginFinder", "Plugin Finder", mobase.VersionInfo(1,2,1, mobase.ReleaseType.ALPHA))
+        super().__init__("PluginFinder", "Plugin Finder", mobase.VersionInfo(1,2,2, mobase.ReleaseType.ALPHA))
 
     def init(self, organiser=mobase.IOrganizer):
         self.pluginfinder = PluginFinder(organiser)


### PR DESCRIPTION
I noticed a file that was renamed in a newer version of my LOOT Warning Checker plugin was left behind with the old name after updating through Plugin Finder. The new version of the file was still installed correctly, but it did not replace the file with the old name. I think the files from the existing version of the plugin should be removed before installing the new version when updating to prevent cluttering the installation directory.

This PR adds a check to the `PluginFinder.install` method to first uninstall the existing version of a plugin if found.
