### PR TITLE
Plugin Finder: Add update notifier plugin

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -5,6 +5,7 @@ from .essentials.rootbuilder import RootBuilderEssentials
 from .essentials.reinstaller import ReinstallerEssentials
 from .essentials.shortcutter import ShortcutterEssentials
 from .essentials.pluginfinder import PluginFinderEssentials
+from .essentials.pluginfinder_notifier import PluginFinderNotifierEssentials
 from .essentials.curationclub import CurationClubEssentials
 from .essentials.profilesync import ProfileSyncEssentials
 
@@ -28,6 +29,7 @@ def createPlugins():
     pfInit = pluginDir / "pluginfinder" / "__init__.py"
     if not pfInit.exists():
         plugins.append(PluginFinderEssentials())
+        plugins.append(PluginFinderNotifierEssentials())
 
     ccInit = pluginDir / "curationclub" / "__init__.py"
     if not ccInit.exists():

--- a/src/essentials/pluginfinder_notifier.py
+++ b/src/essentials/pluginfinder_notifier.py
@@ -1,0 +1,8 @@
+import mobase
+
+from ..pluginfinder.plugins.pluginfinder_notifier import PluginFinderNotifier
+
+
+class PluginFinderNotifierEssentials(PluginFinderNotifier):
+    def init(self, organiser: mobase.IOrganizer) -> bool:
+        return super().init(organiser)

--- a/src/pluginfinder/plugins/pluginfinder_notifier.py
+++ b/src/pluginfinder/plugins/pluginfinder_notifier.py
@@ -1,0 +1,135 @@
+import itertools
+import os
+import subprocess
+from typing import Dict, List, NamedTuple, Optional
+
+import mobase
+
+from ..models.plugin_version import PluginVersion
+from ..pluginfinder import PluginFinder
+from ..pluginfinder_plugin import PluginFinderPlugin
+
+try:
+    from PyQt5.QtCore import qInfo
+except ImportError:
+    from PyQt6.QtCore import qInfo
+
+
+class PluginUpdateNotification(NamedTuple):
+    pluginId: str
+    pluginName: str
+    currentVersion: str
+    newVersion: str
+    releaseNotes: List[str]
+
+
+class PluginFinderNotifier(PluginFinderPlugin, mobase.IPluginDiagnose):
+
+    __notifications: Dict[int, PluginUpdateNotification] = {}
+
+    def init(self, organiser: mobase.IOrganizer) -> bool:
+        super().init(organiser)
+        self.__pluginfinder = PluginFinder(self.organiser)
+        self.__updateNotifications()
+        return True
+
+    def name(self) -> str:
+        return "Plugin Finder Notifier"
+
+    def author(self) -> str:
+        return "Jonathan Feenstra"
+
+    def description(self) -> str:
+        return "Notifies the user when new updates are available for installed plugins."
+
+    def settings(self) -> List[mobase.PluginSetting]:
+        return []
+
+    def activeProblems(self) -> List[int]:
+        return list(self.__notifications.keys())
+
+    def fullDescription(self, key: int) -> str:
+        notification = self.__notifications[key]
+        description = (
+            f"{self.tr('A new update is available for plugin')} <b>{notification.pluginName}</b><br/><br/>"
+            f"{self.tr('Current version')}: <b>{notification.currentVersion}</b><br/>"
+            f"{self.tr('New version')}: <b>{notification.newVersion}</b>"
+        )
+        if notification.releaseNotes:
+            description += (
+                f"<br/><br/>{self.tr('Release notes')}:<ul>"
+                + "".join(f"<li>{note}</li>" for note in notification.releaseNotes)
+                + "</ul>"
+            )
+        return description
+
+    def shortDescription(self, key: int) -> str:
+        notification = self.__notifications[key]
+        return self.tr("New update available for plugin {0}").format(
+            notification.pluginName
+        )
+
+    def hasGuidedFix(self, key: int) -> bool:
+        return True
+
+    def startGuidedFix(self, key: int) -> None:
+        self.__pluginfinder.install(self.__notifications[key].pluginId)
+        self.__restartModOrganizer()
+
+    def __updateNotifications(self) -> None:
+        key = 0
+        for (
+            pluginId,
+            currentData,
+        ) in self.__pluginfinder.installer.getInstalledFiles().items():
+            currentVersion = currentData["Version"]
+            currentVersionInfo = mobase.VersionInfo(currentVersion)
+            latestData = self.__pluginfinder.search.pluginData(pluginId)
+            newVersionData = latestData.current(
+                self.organiser.appVersion().canonicalString()
+            )
+            if newVersionData is not None:
+                newVersion = newVersionData.version()
+                newVersionInfo = mobase.VersionInfo(newVersion)
+                if newVersionInfo > currentVersionInfo:
+                    releaseNotes = self.__getReleaseNotesBetweenVersions(
+                        latestData.versions(),
+                        currentVersionInfo,
+                        newVersionInfo,
+                    )
+                    self.__notifications[key] = PluginUpdateNotification(
+                        pluginId,
+                        latestData.name(),
+                        currentVersion,
+                        newVersion,
+                        releaseNotes,
+                    )
+                    key += 1
+
+    def __getReleaseNotesBetweenVersions(
+        self,
+        allVersions: Optional[List[PluginVersion]],
+        currentVersionInfo: mobase.VersionInfo,
+        newVersionInfo: mobase.VersionInfo,
+    ) -> List[str]:
+        return (
+            list(
+                itertools.chain.from_iterable(
+                    version.releaseNotes()
+                    for version in allVersions
+                    if (versionInfo := mobase.VersionInfo(version.version()))
+                    > currentVersionInfo
+                    and versionInfo <= newVersionInfo
+                )
+            )
+            if allVersions is not None
+            else []
+        )
+
+    def __restartModOrganizer(self) -> None:
+        qInfo("Plugin updated, restarting Mod Organizer.")
+        tkExe = "C:/Windows/system32/taskkill.exe"
+        moExe = self.__pluginfinder.paths.modOrganizerExePath()
+        moKill = f'"{tkExe}" /F /IM ModOrganizer.exe && explorer "{moExe}"'
+        qInfo(f"Executing command {moKill}")
+        subprocess.call(moKill, shell=True, stdout=open(os.devnull, "wb"))

--- a/src/pluginfinder_init.py
+++ b/src/pluginfinder_init.py
@@ -1,8 +1,13 @@
+from typing import List
+
 import mobase
+
 from .pluginfinder.plugins.pluginfinder_browser import PluginFinderBrowser
+from .pluginfinder.plugins.pluginfinder_notifier import PluginFinderNotifier
 
-def createPlugins():
+
+def createPlugins() -> List[mobase.IPlugin]:
     return [
-        PluginFinderBrowser()
-        ]
-
+        PluginFinderBrowser(),
+        PluginFinderNotifier(),
+    ]


### PR DESCRIPTION
This PR adds an `IPluginDiagnose` to Plugin Finder: `PluginFinderNotifier`. It displays notifications on startup if newer versions of your installed plugins are available (that are still supported on the current version of Mod Organizer). Each notification has a guided fix to update to the latest supported version of the plugin by clicking the "Fix" button. Mod Organizer will be restarted after the update.

I decided not to inherit from `PluginFinderPlugin` because it contains some methods that are specific to `IPluginTool` (e.g. `displayName()` and `tooltip()` which are inherited from `SharedPlugin`), as well as the `isActive()` method which is no longer used according to Holt59. I think it would be best to remove those methods from `SharedPlugin` and maybe create a new `SharedPluginTool` class that inherits from `SharedPlugin`.

I have not tested this with Qt 6 yet.