### PR TITLE
Linkmode without UVFS

### DIFF
--- a/src/rootbuilder/modules/rootbuilder_backup.py
+++ b/src/rootbuilder/modules/rootbuilder_backup.py
@@ -134,8 +134,7 @@ class RootBuilderBackup():
             else:
                 conflictFiles = self.files.getRootModFiles()
             # Loop through the mod files and see if we have data for them.
-            for file in conflictFiles:
-                relativePath = self.paths.rootRelativePath(file)
+            for relativePath in conflictFiles:
                 gamePath = self.paths.gamePath() / relativePath
                 # If we have data, we need to back this file up.
                 if str(gamePath) in fileData:

--- a/src/rootbuilder/modules/rootbuilder_copy.py
+++ b/src/rootbuilder/modules/rootbuilder_copy.py
@@ -29,8 +29,7 @@ class RootBuilderCopy():
         # Get list of current mod files.
         modFiles = self.files.getRootModFiles()
         # Iterate over current mod files and update our data.
-        for file in modFiles:
-            relativePath = self.paths.rootRelativePath(file)
+        for relativePath, file in modFiles.items():
             modFileData = {
                     "Path" : str(file),
                     "Hash" : str(self.utilities.hashFile(file))

--- a/src/rootbuilder/modules/rootbuilder_linker.py
+++ b/src/rootbuilder/modules/rootbuilder_linker.py
@@ -50,8 +50,13 @@ class RootBuilderLinker():
             for relativePath, file in linkFileData.items():
                 gamePath = self.paths.gamePath() / relativePath
                 if gamePath.exists():
-                    #qInfo("Removing link for " + str(gamePath))
-                    gamePath.unlink(True)
+                    if os.stat(gamePath).st_nlink <= 1:
+                        # Hard link got replaced by new file
+                        # qInfo(f"Hard link {relativePath} was replaced, updating: {file}")
+                        self.utilities.moveTo(gamePath, file)
+                    else:
+                        #qInfo("Removing link for " + str(gamePath))
+                        gamePath.unlink(True)
                 if Path(str(gamePath) + ".rbackup").exists():
                     #qInfo("Renaming from link " + str(gamePath))
                     self.utilities.moveTo(Path(str(gamePath) + ".rbackup"), gamePath)

--- a/src/rootbuilder/modules/rootbuilder_linker.py
+++ b/src/rootbuilder/modules/rootbuilder_linker.py
@@ -22,8 +22,7 @@ class RootBuilderLinker():
         """ Generates links for all linkable mod files and saves records of each of them """
         # Get all linkable mod files.
         linkFileData = self.files.getLinkableModFiles()
-        for file in linkFileData:
-            relativePath = self.paths.rootRelativePath(file)
+        for relativePath, file in linkFileData.items():
             gamePath = self.paths.gamePath() / relativePath
             # If the linkable file is already in the game folder, rename it.
             if gamePath.exists():
@@ -40,6 +39,7 @@ class RootBuilderLinker():
             self.paths.rootLinkDataFilePath().touch()
         with open(self.paths.rootLinkDataFilePath(), "w", encoding="utf-8") as jsonFile:
             json.dump(linkFileData, jsonFile)
+        return linkFileData
 
     def clear(self):
         """ Clears any created links from mod files """
@@ -47,8 +47,7 @@ class RootBuilderLinker():
         if self.paths.rootLinkDataFilePath().exists():
             linkFileData = json.load(open(self.paths.rootLinkDataFilePath(),"r", encoding="utf-8"))
             # Loop through our link data and unlink individual files.
-            for file in linkFileData:
-                relativePath = self.paths.rootRelativePath(file)
+            for relativePath, file in linkFileData.items():
                 gamePath = self.paths.gamePath() / relativePath
                 if gamePath.exists():
                     #qInfo("Removing link for " + str(gamePath))

--- a/src/rootbuilder/rootbuilder.py
+++ b/src/rootbuilder/rootbuilder.py
@@ -41,12 +41,11 @@ class RootBuilder():
         qInfo("RootBuilder: Backing up files.")
         self.backup.backup()
         qInfo("RootBuilder: Backed up files.")
-        if self.settings.usvfsmode():
-            if self.settings.linkmode():
-                qInfo("RootBuilder: Generating links.")
-                self.linker.build()
-                qInfo("RootBuilder: Links generated.")
-        else:
+        if self.settings.linkmode():
+            qInfo("RootBuilder: Generating links.")
+            self.linker.build()
+            qInfo("RootBuilder: Links generated.")
+        elif not self.settings.usvfsmode():
             qInfo("RootBuilder: Copying files.")
             self.copier.build()
             qInfo("RootBuilder: Files copied.")


### PR DESCRIPTION
Adds the option to use link mode without UVFS (link mode as toggle in the UI).
(includes #15)

TODO:
- [x] Handle replaced files (removes hardlink, `.unlink()` would delete file).
- [x] Check copier and linker interaction (when to exclude linked files from copy / sync)