### PR TITLE
Linkmode blacklist mode

### DIFF
--- a/src/rootbuilder/modules/rootbuilder_files.py
+++ b/src/rootbuilder/modules/rootbuilder_files.py
@@ -102,17 +102,15 @@ class RootBuilderFiles(SharedFiles):
     def getLinkableModFiles(self):
         """ Gets a list of all root files in active mods that are valid for linking """
         # Get all root files in currently active mods.
-        modFiles = self.getRootModFiles()
         linkableFiles = []
         # Loop through the files in each mod and look for linkable extensions.
-        for file in modFiles:
-            exclude = True
+        linked_extensions = set(self.settings.linkextensions())
+        for file in self.getRootModFiles():
+            # Exclude files with * in list instead of including them
+            exclude = False if "*" in linked_extensions else True
             # Loop through the linkable extensions and look for a match.
-            for ex in self.settings.linkextensions():
-                if (str(file)).endswith("." + ex):
-                    exclude = False
-            if exclude == False:
+            if (ext := Path(file).suffix[1:]) != "" and ext in linked_extensions:
+                exclude = not exclude
+            if exclude is False:
                 linkableFiles.append(file)
         return linkableFiles
-
-    

--- a/src/rootbuilder/modules/rootbuilder_files.py
+++ b/src/rootbuilder/modules/rootbuilder_files.py
@@ -106,11 +106,10 @@ class RootBuilderFiles(SharedFiles):
         # Loop through the files in each mod and look for linkable extensions.
         linked_extensions = set(self.settings.linkextensions())
         for file in self.getRootModFiles():
-            # Exclude files with * in list instead of including them
-            exclude = False if "*" in linked_extensions else True
             # Loop through the linkable extensions and look for a match.
-            if (ext := Path(file).suffix[1:]) != "" and ext in linked_extensions:
-                exclude = not exclude
-            if exclude is False:
+            # Backlist with *, exclude from blacklist with ^.ext
+            if (ext := Path(file).suffix[1:]) in linked_extensions or (
+                "*" in linked_extensions and f"^{ext}" not in linked_extensions
+            ):
                 linkableFiles.append(file)
         return linkableFiles

--- a/src/rootbuilder/plugins/rootbuilder_tool_manage.py
+++ b/src/rootbuilder/plugins/rootbuilder_tool_manage.py
@@ -443,7 +443,7 @@ class RootBuilderManageTool(RootBuilderPlugin, mobase.IPluginTool):
         self.extensionsDescLabel.setSizePolicy(sizePolicy)
         self.extensionsDescLabel.setWordWrap(True)
         self.extensionsDescLabel.setObjectName("extensionsDescLabel")
-        self.extensionsDescLabel.setText("List of file extensions to create links for when using Link mode.")
+        self.extensionsDescLabel.setText("List of file extensions to create links for when using Link mode. Add a * to use as blacklist.")
         self.extensionsLayout.addWidget(self.extensionsDescLabel)
         self.textSettingLayout.addWidget(self.extensionsLabelWidget)
         

--- a/src/rootbuilder/plugins/rootbuilder_tool_manage.py
+++ b/src/rootbuilder/plugins/rootbuilder_tool_manage.py
@@ -443,7 +443,7 @@ class RootBuilderManageTool(RootBuilderPlugin, mobase.IPluginTool):
         self.extensionsDescLabel.setSizePolicy(sizePolicy)
         self.extensionsDescLabel.setWordWrap(True)
         self.extensionsDescLabel.setObjectName("extensionsDescLabel")
-        self.extensionsDescLabel.setText("List of file extensions to create links for when using Link mode. Add a * to use as blacklist.")
+        self.extensionsDescLabel.setText("List of file extensions to create links for when using Link mode. Include all files with * (except ^ext).")
         self.extensionsLayout.addWidget(self.extensionsDescLabel)
         self.textSettingLayout.addWidget(self.extensionsLabelWidget)
         


### PR DESCRIPTION
Adds a blacklist option to link mode, using `*`:
- `ext1,ext2` creates links only for `.ext1` and `.ext2` (as before).
- `*,^ext1,^ext2` will include all files except `.ext1` and `.ext2`.