### PR TITLE
fix typo 'fules' -> 'rules' in Root Builder exclusions description

### DIFF
--- a/src/plugin/rootbuilder/ui/qt5/rootbuilder_exclusions.py
+++ b/src/plugin/rootbuilder/ui/qt5/rootbuilder_exclusions.py
@@ -49,4 +49,4 @@ class Ui_exclusionsTabWidget(object):
         _translate = QtCore.QCoreApplication.translate
         exclusionsTabWidget.setWindowTitle(_translate("exclusionsTabWidget", "Form"))
         self.exclusionsTitle.setText(_translate("exclusionsTabWidget", "Exclusions"))
-        self.exclusionsDesc.setText(_translate("exclusionsTabWidget", "Files matching the specified fules will be completely ignored by Root Builder. They will not be included in the backup or cache and they will be ignored from any mods they are present in. Supports glob wildcards, and regex expressions when using the prefix r:"))
+        self.exclusionsDesc.setText(_translate("exclusionsTabWidget", "Files matching the specified rules will be completely ignored by Root Builder. They will not be included in the backup or cache and they will be ignored from any mods they are present in. Supports glob wildcards, and regex expressions when using the prefix r:"))

--- a/src/plugin/rootbuilder/ui/qt6/rootbuilder_exclusions.py
+++ b/src/plugin/rootbuilder/ui/qt6/rootbuilder_exclusions.py
@@ -47,4 +47,4 @@ class Ui_exclusionsTabWidget(object):
         _translate = QtCore.QCoreApplication.translate
         exclusionsTabWidget.setWindowTitle(_translate("exclusionsTabWidget", "Form"))
         self.exclusionsTitle.setText(_translate("exclusionsTabWidget", "Exclusions"))
-        self.exclusionsDesc.setText(_translate("exclusionsTabWidget", "Files matching the specified fules will be completely ignored by Root Builder. They will not be included in the backup or cache and they will be ignored from any mods they are present in. Supports glob wildcards, and regex expressions when using the prefix r:"))
+        self.exclusionsDesc.setText(_translate("exclusionsTabWidget", "Files matching the specified rules will be completely ignored by Root Builder. They will not be included in the backup or cache and they will be ignored from any mods they are present in. Supports glob wildcards, and regex expressions when using the prefix r:"))

--- a/src/plugin/rootbuilder/ui/rootbuilder_exclusions.ui
+++ b/src/plugin/rootbuilder/ui/rootbuilder_exclusions.ui
@@ -40,7 +40,7 @@
    <item>
     <widget class="QLabel" name="exclusionsDesc">
      <property name="text">
-      <string>Files matching the specified fules will be completely ignored by Root Builder. They will not be included in the backup or cache and they will be ignored from any mods they are present in. Supports glob wildcards, and regex expressions when using the prefix r:</string>
+      <string>Files matching the specified rules will be completely ignored by Root Builder. They will not be included in the backup or cache and they will be ignored from any mods they are present in. Supports glob wildcards, and regex expressions when using the prefix r:</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>


### PR DESCRIPTION
Fixes a small typo "fules" -> "rules" that I noticed in the description of exclusions in Root Builder.

![image](https://github.com/Kezyma/ModOrganizer-Plugins/assets/16735852/1c95b322-783f-4d67-93ea-52d2042e1364)
