### PR TITLE
pluginfinder: add Bethesda Plugin Manager

### DIFF
--- a/src/plugin/pluginfinder/data/pluginfinder_directory.json
+++ b/src/plugin/pluginfinder/data/pluginfinder_directory.json
@@ -113,5 +113,10 @@
     "Name": "Auto-Activator",
     "Identifier": "autoactivator",
     "Manifest": "https://raw.githubusercontent.com/JonathanFeenstra/modorganizer-auto-activator/main/manifest.json"
+  },
+  {
+    "Name": "Bethesda Plugin Manager",
+    "Identifier": "bsplugins",
+    "Manifest": "https://raw.githubusercontent.com/Exit-9B/modorganizer-bsplugins/main/plugindefinition.json"
   }
 ]


### PR DESCRIPTION
Add [Parapet's Bethesda Plugin Manager](https://github.com/Exit-9B/modorganizer-bsplugins) to the plugin directory.