### PR TITLE
reinstaller: add "no copy" option

### DIFF
--- a/src/plugin/reinstaller/core/reinstaller.py
+++ b/src/plugin/reinstaller/core/reinstaller.py
@@ -1,10 +1,11 @@
-import mobase, subprocess, os
+import mobase
 from pathlib import Path
 from ....common.common_log import CommonLog
 from ....common.common_utilities import *
 from .reinstaller_settings import ReinstallerSettings
 from ..modules.reinstaller_strings import ReinstallerStrings
-from ..modules.reinstaller_paths import ReinstallerPaths
+from ..modules.reinstaller_paths import ReinstallerPaths, ReinstallerPathsNoCopy
+
 
 class Reinstaller:
     """Core Shortcutter class that handles all plugin functionality."""
@@ -21,13 +22,13 @@ class Reinstaller:
         destFilePath = backupFolderPath / file
         sourcePath = Path(self._strings.moDownloadsPath) / file
         copyFile(sourcePath, destFilePath)
-        
+
         metaSourcePath = Path(Path(self._strings.moDownloadsPath) / (str(file) + ".meta"))
         if metaSourcePath.exists():
             metaDestPath = backupFolderPath / (str(file) + ".meta")
             copyFile(metaSourcePath, metaDestPath)
         return name
-        
+
     def install(self, name, file):
         modPath = Path(self._strings.pluginDataPath) / name / file
         self._organiser.installMod(modPath, str(name))
@@ -39,9 +40,36 @@ class Reinstaller:
         metaPath = Path(Path(self._strings.pluginDataPath) / name / (file + ".meta"))
         if metaPath.exists():
             deleteFile(metaPath)
-        
+
         fileOptions = self._paths.getInstallerFileOptions(name)
-        if (len(fileOptions) == 0):
+        if len(fileOptions) == 0:
             folderPath = Path(self._strings.pluginDataPath) / name
             deleteFolder(folderPath)
+        return name
+
+
+class ReinstallerNoCopy(Reinstaller):
+    """Alternative core class that handles all plugin functionality for setups
+    where the mod installer are not copied to the plugin data folder (e.g. Wabbajack)"""
+
+    def __init__(self, organiser: mobase.IOrganizer) -> None:
+        super().__init__(organiser)
+
+        self._paths = ReinstallerPathsNoCopy("Reinstaller", self._organiser, self._settings, self._strings)
+
+    def create(self, name, file) -> str:
+        entries = self._paths.readDatabase()
+        entries.append([name, file])
+        self._paths.writeDatabase(entries)
+        return name
+
+    def install(self, name, file) -> str:
+        modPath = Path(self._strings.moDownloadsPath) / file
+        self._organiser.installMod(modPath, str(name))
+        return name
+
+    def delete(self, name, file) -> str:
+        entries = self._paths.readDatabase()
+        entries = [entry for entry in entries if not (entry[0] == name and entry[1] == file)]
+        self._paths.writeDatabase(entries)
         return name

--- a/src/plugin/reinstaller/core/reinstaller_plugin.py
+++ b/src/plugin/reinstaller/core/reinstaller_plugin.py
@@ -3,11 +3,13 @@ from pathlib import Path
 from ....base.base_plugin import BasePlugin
 from ....common.common_update import CommonUpdate
 from ....common.common_help import CommonHelp
-from .reinstaller import Reinstaller
+from .reinstaller import Reinstaller, ReinstallerNoCopy
+
 try:
     from PyQt5.QtCore import QCoreApplication
-except:
+except ImportError:
     from PyQt6.QtCore import QCoreApplication
+
 
 class ReinstallerPlugin(BasePlugin):
     """Base Reinstaller plugin, to be inherited by all other plugins."""
@@ -15,25 +17,42 @@ class ReinstallerPlugin(BasePlugin):
     def __init__(self):
         super().__init__("Reinstaller", "Reinstaller", mobase.VersionInfo(2, 0, 0))
 
-    def init(self, organiser:mobase.IOrganizer):
-        self._reinstaller = Reinstaller(organiser)
+    def init(self, organiser: mobase.IOrganizer):
+        if organiser.pluginSetting(self.name(), "copy_installers"):
+            self._reinstaller = Reinstaller(organiser)
+        else:
+            self._reinstaller = ReinstallerNoCopy(organiser)
+
         self._update = CommonUpdate(
-            "https://raw.githubusercontent.com/Kezyma/ModOrganizer-Plugins/main/directory/plugins/reinstaller.json", 
-            "https://www.nexusmods.com/skyrimspecialedition/mods/59292?tab=files", 
-            self, self._reinstaller._strings, self._reinstaller._log)
-        self._help = CommonHelp(Path(__file__).parent.parent / "data" / "reinstaller_help.html", 
-                                "reinstaller", "skyrimspecialedition", "59292", 
-                                self._reinstaller._strings, self._reinstaller._log)
+            "https://raw.githubusercontent.com/Kezyma/ModOrganizer-Plugins/main/directory/plugins/reinstaller.json",
+            "https://www.nexusmods.com/skyrimspecialedition/mods/59292?tab=files",
+            self,
+            self._reinstaller._strings,
+            self._reinstaller._log,
+        )
+        self._help = CommonHelp(
+            Path(__file__).parent.parent / "data" / "reinstaller_help.html",
+            "reinstaller",
+            "skyrimspecialedition",
+            "59292",
+            self._reinstaller._strings,
+            self._reinstaller._log,
+        )
         return super().init(organiser)
 
     def __tr(self, trstr):
         return QCoreApplication.translate(self._pluginName, trstr)
-    
+
     def settings(self):
-        """ Current list of game settings for Mod Organizer. """
+        """Current list of game settings for Mod Organizer."""
         baseSettings = super().settings()
-        customSettings = []
+        customSettings = [
+            mobase.PluginSetting(
+                "copy_installers",
+                "Backup installers out of download folder",
+                True,
+            ),
+        ]
         for setting in customSettings:
             baseSettings.append(setting)
         return baseSettings
-        

--- a/src/plugin/reinstaller/modules/reinstaller_paths.py
+++ b/src/plugin/reinstaller/modules/reinstaller_paths.py
@@ -1,15 +1,16 @@
-import mobase, glob, re, os
+import re
+import os
+import mobase
 from pathlib import Path
 from .reinstaller_strings import ReinstallerStrings
 from ..core.reinstaller_settings import ReinstallerSettings
 from ....common.common_paths import CommonPaths
-from ....common.common_log import CommonLog
-from typing import List
+
 
 class ReinstallerPaths(CommonPaths):
     """Reinstaller paths module, contains path related functions for Reinstaller."""
 
-    def __init__(self, plugin:str, organiser:mobase.IOrganizer, settings:ReinstallerSettings, strings:ReinstallerStrings):
+    def __init__(self, plugin: str, organiser: mobase.IOrganizer, settings: ReinstallerSettings, strings: ReinstallerStrings):
         super().__init__(plugin, organiser)
         self._strings = strings
         self._settings = settings
@@ -18,11 +19,12 @@ class ReinstallerPaths(CommonPaths):
         downloadFiles = self.files(self._strings.moDownloadsPath)
         modFiles = []
         for file in downloadFiles:
-            if not str(file).endswith('.meta') and not str(file).endswith('.unfinished'):
+            if not str(file).endswith(".meta") and not str(file).endswith(".unfinished"):
                 modFiles.append(str(os.path.basename(file)))
         return modFiles
 
     metaRegex = r"^modName=(.+)$"
+
     def getDownloadFileName(self, downloadName=str):
         defaultName = str(downloadName).split("_")[0].split("-")[0].split(".")[0].strip()
         metaPath = str(Path(self._strings.moDownloadsPath) / (str(downloadName) + ".meta"))
@@ -39,7 +41,7 @@ class ReinstallerPaths(CommonPaths):
             except:
                 return defaultName
         return defaultName
-    
+
     def getInstallerOptions(self):
         installers = self.subfolders(self._strings.pluginDataPath)
         names = []
@@ -51,8 +53,41 @@ class ReinstallerPaths(CommonPaths):
         installerOpts = self.files(Path(self._strings.pluginDataPath) / name)
         files = []
         for file in installerOpts:
-            if not str(file).endswith('.meta'):
+            if not str(file).endswith(".meta"):
                 files.append(str(file))
         return files
 
 
+class ReinstallerPathsNoCopy(ReinstallerPaths):
+    """Reinstaller paths module for no copy setup"""
+
+    def __init__(self, plugin: str, organiser: mobase.IOrganizer, settings: ReinstallerSettings, strings: ReinstallerStrings):
+        super().__init__(plugin, organiser, settings, strings)
+        self._db_file = Path(self._strings.pluginDataPath) / "installers.txt"
+
+    def readDatabase(self) -> list[str]:
+        if not self._db_file.exists():
+            return []
+        with open(self._db_file, "r") as file:
+            entries = [line.strip().split(",") for line in file.readlines()]
+        return entries
+
+    def writeDatabase(self, entries) -> None:
+        with open(self._db_file, "w") as file:
+            for entry in entries:
+                file.write(",".join(entry) + "\n")
+
+    def getInstallerEntries(self):
+        entries = self.readDatabase()
+        installerEntries = {}
+        for name, file in entries:
+            if name not in installerEntries:
+                installerEntries[name] = []
+            installerEntries[name].append(file)
+        return installerEntries
+
+    def getInstallerOptions(self):
+        return list(self.getInstallerEntries().keys())
+
+    def getInstallerFileOptions(self, name):
+        return self.getInstallerEntries().get(name, [])

--- a/src/plugin/reinstaller/modules/reinstaller_paths.py
+++ b/src/plugin/reinstaller/modules/reinstaller_paths.py
@@ -87,7 +87,7 @@ class ReinstallerPathsNoCopy(ReinstallerPaths):
         return installerEntries
 
     def getInstallerOptions(self):
-        return list(self.getInstallerEntries().keys())
+        return sorted(list(self.getInstallerEntries().keys()))
 
     def getInstallerFileOptions(self, name):
         return self.getInstallerEntries().get(name, [])

--- a/src/plugin/reinstaller/plugins/reinstaller_quickdelete.py
+++ b/src/plugin/reinstaller/plugins/reinstaller_quickdelete.py
@@ -6,11 +6,12 @@ from ....base.base_dialog import BaseDialog
 from ....common.common_qt import *
 from ....common.common_icons import MINUS_ICON
 
+
 class ReinstallerQuickDelete(ReinstallerPlugin, mobase.IPluginTool):
     def __init__(self):
         super().__init__()
 
-    def init(self, organiser:mobase.IOrganizer):
+    def init(self, organiser: mobase.IOrganizer):
         res = super().init(organiser)
         self.dialog = QtWidgets.QWidget()
         return res
@@ -23,7 +24,7 @@ class ReinstallerQuickDelete(ReinstallerPlugin, mobase.IPluginTool):
 
     def icon(self):
         return MINUS_ICON
-    
+
     def settings(self):
         return []
 
@@ -35,8 +36,14 @@ class ReinstallerQuickDelete(ReinstallerPlugin, mobase.IPluginTool):
 
     def description(self):
         return self.__tr("Deletes a downloaded file.")
-    
+
     def display(self):
+        if self._organiser.pluginSetting("Reinstaller", "copy_installers"):
+            self._display()
+        else:
+            self._display_no_copy()
+
+    def _display(self):
         installers = self._reinstaller._paths.subfolders(self._reinstaller._strings.pluginDataPath)
         names = []
         for folder in installers:
@@ -47,7 +54,7 @@ class ReinstallerQuickDelete(ReinstallerPlugin, mobase.IPluginTool):
             installerOpts = self._reinstaller._paths.files(str(Path(self._reinstaller._strings.pluginDataPath) / item))
             files = []
             for file in installerOpts:
-                if not str(file).endswith('.meta'):
+                if not str(file).endswith(".meta"):
                     files.append(file)
             if len(files) == 1:
                 self._reinstaller.delete(item, os.path.basename(files[0]))
@@ -59,3 +66,12 @@ class ReinstallerQuickDelete(ReinstallerPlugin, mobase.IPluginTool):
                 if ok and item2:
                     self._reinstaller.delete(item, item2)
 
+    def _display_no_copy(self):
+        entries = self._reinstaller._paths.getInstallerEntries()
+        names = self._reinstaller._paths.getInstallerOptions()
+        item, ok = QInputDialog.getItem(self.dialog, "Delete Installer", "Installer:", names, 0, False)
+
+        if ok and item:
+            item2, ok = QInputDialog.getItem(self.dialog, "Delete File", "File:", entries[item], 0, False)
+            if ok and item2:
+                self._reinstaller.delete(item, item2)


### PR DESCRIPTION
Add a "no copy" option for reinstaller which use a text file (`MO2Plugins/Data/Reinstaller/installers.txt`) that list the installers instead of copying the files to the plugin data folder. 

I believe this could be useful for users as myself that prefer to keep all the downloaded files (for Wabbajack purposes for example).

This is implemented by adding `no_copy` setting to the plugin. If set to true (default behavior) the plugin keeps its original behavior. If set to false, the plugin uses a subclass of `Reinstaller` and `ReinstallerPaths` that implements the use of the text files.
The drawback of this implementation is that because the plugin is already loaded when the setting is changed, MO2 must be restarted to apply the new behavior. However, this is standard practice for MO2 plugins, so it shouldn't pose a significant issue.

Marking this PR as a draft for now because I have not yet tested the behavior of the quick install and quick delete menus. So far, I have only implemented and tested the full reinstaller menu.

Also, I left the changes made by my linter, Ruff, to the files I touched, but I can remove them if necessary.
