### PR TITLE
Fix deprecated/removed Path.link_to

### DIFF
--- a/src/common/common_utilities.py
+++ b/src/common/common_utilities.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Any, Union
 import sys
 import time
-import encodings.idna
 
 
 # Backwards compatibility: Path.link_to was deprecated in 3.10, removed in 3.12

--- a/src/common/common_utilities.py
+++ b/src/common/common_utilities.py
@@ -1,8 +1,22 @@
 import json, shutil, os, stat, hashlib, urllib.request
 from pathlib import Path
-from typing import Any
+from typing import Any, Union
+import sys
 import time
 import encodings.idna
+
+
+# Backwards compatibility: Path.link_to was deprecated in 3.10, removed in 3.12
+if sys.version_info[0] >= 3 and sys.version_info[1] < 10:
+
+    def hardlink(source: Union[str, Path], target: Union[str, Path]):
+        Path(source).link_to(target)
+
+else:
+
+    def hardlink(source: Union[str, Path], target: Union[str, Path]):
+        Path(target).hardlink_to(source)
+
 
 def maxRetries():
     return 10
@@ -91,7 +105,7 @@ def linkFile(source: str, dest: str, retries = 0) -> bool:
     """Links a file to a specific location."""
     try:
         os.makedirs(os.path.dirname(dest), exist_ok=True)
-        Path(source).link_to(dest)
+        hardlink(source, dest)
         return True
     except:
         if retries <= maxRetries():

--- a/src/common/common_utilities.py
+++ b/src/common/common_utilities.py
@@ -1,7 +1,7 @@
 import urllib.error
 import json, shutil, os, stat, hashlib, urllib.request
 from pathlib import Path
-from typing import Any, Union
+from typing import Any, Iterable, Union
 import sys
 import time
 
@@ -21,7 +21,7 @@ else:
 def maxRetries():
     return 10
 
-def copyFileOrFolder(source: str, dest: str, retries = 0) -> bool:
+def copyFileOrFolder(source: str, dest: str, retries: int = 0) -> bool:
     """Copies a file or folder from source to destination."""
     try:
         path = Path(dest)
@@ -37,7 +37,7 @@ def copyFileOrFolder(source: str, dest: str, retries = 0) -> bool:
             return copyFileOrFolder(source, dest, retries + 1)
         return False
 
-def copyFile(source: str, dest: str, retries = 0) -> bool:
+def copyFile(source: str, dest: str, retries: int = 0) -> bool:
     """Copies a file from source to destination."""
     try:
         if (Path(dest).exists()):
@@ -51,7 +51,7 @@ def copyFile(source: str, dest: str, retries = 0) -> bool:
             return copyFile(source, dest, retries + 1)
         return False
 
-def copyFolder(source: str, dest: str, retries = 0) -> bool:
+def copyFolder(source: str, dest: str, retries: int = 0) -> bool:
     """Copies a folder from source to destination."""
     try:
         shutil.copytree(source, dest, dirs_exist_ok=True)
@@ -62,7 +62,7 @@ def copyFolder(source: str, dest: str, retries = 0) -> bool:
             return copyFolder(source, dest, retries + 1)
         return False
 
-def moveFile(source: str, dest: str, retries = 0) -> bool:
+def moveFile(source: str, dest: str, retries: int = 0) -> bool:
     """Moves a file from source to destination."""
     try:
         if (Path(dest).exists()):
@@ -76,7 +76,7 @@ def moveFile(source: str, dest: str, retries = 0) -> bool:
             return moveFile(source, dest, retries + 1)
         return False
 
-def deleteFile(file: str, retries = 0) -> bool:
+def deleteFile(file: str, retries: int = 0) -> bool:
     """Deletes a file."""
     try:
         if (Path(file).exists()):
@@ -88,8 +88,8 @@ def deleteFile(file: str, retries = 0) -> bool:
             time.sleep(0.1)
             return deleteFile(file, retries + 1)
         return False
-    
-def deleteFolder(file: str, retries = 0) -> bool:
+
+def deleteFolder(file: str, retries: int = 0) -> bool:
     """Deletes a folder."""
     try:
         if Path(file).exists():
@@ -101,7 +101,7 @@ def deleteFolder(file: str, retries = 0) -> bool:
             return deleteFolder(file, retries + 1)
         return False
 
-def linkFile(source: str, dest: str, retries = 0) -> bool:
+def linkFile(source: str, dest: str, retries: int = 0) -> bool:
     """Links a file to a specific location."""
     try:
         os.makedirs(os.path.dirname(dest), exist_ok=True)
@@ -113,7 +113,7 @@ def linkFile(source: str, dest: str, retries = 0) -> bool:
             return linkFile(source, dest, retries + 1)
         return False
 
-def unlinkFile(link: str, retries = 0) -> bool:
+def unlinkFile(link: str, retries: int = 0) -> bool:
     """Unlinks a file."""
     try:
         Path(link).unlink()
@@ -124,7 +124,7 @@ def unlinkFile(link: str, retries = 0) -> bool:
             return unlinkFile(link, retries + 1)
         return False
 
-def saveJson(path: str, data: Any, retries = 0) -> bool:
+def saveJson(path: str, data: Any, retries: int = 0) -> bool:
     """Saves an object to a json file."""
     try:
         os.makedirs(os.path.dirname(path), exist_ok=True)
@@ -136,8 +136,8 @@ def saveJson(path: str, data: Any, retries = 0) -> bool:
             time.sleep(0.1)
             return saveJson(path, data, retries + 1)
         return False
-    
-def loadJson(path: str, retries = 0):
+
+def loadJson(path: str, retries: int = 0) -> Union[Any, None]:
     """Loads an object from a json file."""
     try:
         return json.load(open(Path(path), "r", encoding="utf-8-sig"))
@@ -146,8 +146,8 @@ def loadJson(path: str, retries = 0):
             time.sleep(0.1)
             return loadJson(path, retries + 1)
         return None
-    
-def loadLines(path: str, retries = 0):
+
+def loadLines(path: str, retries: int = 0) -> Union["list[str]", None]:
     """Loads a list of lines from a file."""
     try:
         with open(path, "r", encoding="utf-8-sig") as file:
@@ -158,8 +158,8 @@ def loadLines(path: str, retries = 0):
             time.sleep(0.1)
             return loadLines(path, retries + 1)
         return None
-    
-def saveLines(path: str, data: list, retries = 0) -> bool:
+
+def saveLines(path: str, data: Iterable[str], retries: int = 0) -> bool:
     """Saves a list of lines to a file."""
     try:
         os.makedirs(os.path.dirname(path), exist_ok=True)
@@ -171,7 +171,7 @@ def saveLines(path: str, data: list, retries = 0) -> bool:
             time.sleep(0.1)
             return saveLines(path, data, retries + 1)
         return False
-    
+
 def hashFile(path: str) -> str:
     """ Hashes a file and returns the hash """
     func = hashlib.md5()
@@ -183,7 +183,7 @@ def hashFile(path: str) -> str:
     os.close(f)
     return func.hexdigest()
 
-def downloadFile(url: str, path: str, retries = 0) -> bool:
+def downloadFile(url: str, path: str, retries: int = 0) -> bool:
     """Downloads a file to a specific location."""
     try:
         os.makedirs(os.path.dirname(path), exist_ok=True)
@@ -199,7 +199,7 @@ def downloadFile(url: str, path: str, retries = 0) -> bool:
             time.sleep(0.1)
             return downloadFile(url, path, retries + 1)
         return False
-    
+
 def folderIsEmpty(path: str) -> bool:
     items = os.listdir(path)
     empty = True

--- a/src/common/common_utilities.py
+++ b/src/common/common_utilities.py
@@ -1,10 +1,14 @@
-import urllib.error
-import json, shutil, os, stat, hashlib, urllib.request
-from pathlib import Path
-from typing import Any, Iterable, Union
+import hashlib
+import json
+import os
+import shutil
+import stat
 import sys
 import time
-
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Iterable, Union
 
 # Backwards compatibility: Path.link_to was deprecated in 3.10, removed in 3.12
 if sys.version_info[0] >= 3 and sys.version_info[1] < 10:
@@ -27,9 +31,9 @@ def copyFileOrFolder(source: str, dest: str, retries: int = 0) -> bool:
         path = Path(dest)
         if path.exists():
             if path.is_dir():
-                return copyFolder(source,dest)
+                return copyFolder(source, dest)
             elif path.is_file():
-                return copyFile(source,dest)
+                return copyFile(source, dest)
         return False
     except OSError:
         if retries <= maxRetries():
@@ -40,7 +44,7 @@ def copyFileOrFolder(source: str, dest: str, retries: int = 0) -> bool:
 def copyFile(source: str, dest: str, retries: int = 0) -> bool:
     """Copies a file from source to destination."""
     try:
-        if (Path(dest).exists()):
+        if Path(dest).exists():
             os.chmod(dest, stat.S_IWRITE)
         os.makedirs(os.path.dirname(dest), exist_ok=True)
         shutil.copy2(source, dest)
@@ -65,7 +69,7 @@ def copyFolder(source: str, dest: str, retries: int = 0) -> bool:
 def moveFile(source: str, dest: str, retries: int = 0) -> bool:
     """Moves a file from source to destination."""
     try:
-        if (Path(dest).exists()):
+        if Path(dest).exists():
             os.chmod(dest, stat.S_IWRITE)
         os.makedirs(os.path.dirname(dest), exist_ok=True)
         shutil.move(str(source), str(dest))
@@ -79,7 +83,7 @@ def moveFile(source: str, dest: str, retries: int = 0) -> bool:
 def deleteFile(file: str, retries: int = 0) -> bool:
     """Deletes a file."""
     try:
-        if (Path(file).exists()):
+        if Path(file).exists():
             os.chmod(file, stat.S_IWRITE)
         os.remove(file)
         return True
@@ -173,12 +177,12 @@ def saveLines(path: str, data: Iterable[str], retries: int = 0) -> bool:
         return False
 
 def hashFile(path: str) -> str:
-    """ Hashes a file and returns the hash """
+    """Hashes a file and returns the hash"""
     func = hashlib.md5()
-    if (Path(path).exists()):
+    if Path(path).exists():
         os.chmod(path, stat.S_IWRITE)
     f = os.open(path, (os.O_RDONLY | os.O_BINARY))
-    for block in iter(lambda: os.read(f, 2048*func.block_size), b''):
+    for block in iter(lambda: os.read(f, 2048 * func.block_size), b""):
         func.update(block)
     os.close(f)
     return func.hexdigest()

--- a/src/plugin/pluginfinder/modules/pluginfinder_directory.py
+++ b/src/plugin/pluginfinder/modules/pluginfinder_directory.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from ..models.pluginfinder_directorydata import *
 from ..models.pluginfinder_manifestdata import *
 from ..models.pluginfinder_versiondata import *
-import encodings.idna
 
 class PluginFinderDirectory:
     """Plugin Finder directory module, handles update and loading of the directory file."""


### PR DESCRIPTION
Fixes #36 

Providing compatibility for `Path.link_to()` for Python 3.8 and Python 3.12.

Also fixes:
- error handling: only catch file or request related errors
- typing

I did not change the general file related retries in `common_utilities.py`, but I do not think it makes much sense to always retry 10 times, or whether to retry at all.

I only tested it with MO v2.5.2dev5. A test with MO 2.4 would be good.