### PR TITLE
RootBuilder performance improvements

### DIFF
--- a/src/common/common_utilities.py
+++ b/src/common/common_utilities.py
@@ -214,20 +214,14 @@ def folderIsEmpty(path: str) -> bool:
                 subIsEmpty = folderIsEmpty(fullPath)
                 empty = empty and subIsEmpty
             else:
-                empty = False
+                return False
     return empty
 
-def deleteEmptyFolders(path: str) -> bool:
-    items = os.listdir(path)
-    empty = True
-    if len(items) > 0:
-        for itm in items:
-            fullPath = os.path.join(path, itm)
-            if os.path.isdir(fullPath):
-                subIsEmpty = deleteEmptyFolders(fullPath)
-                empty = empty and subIsEmpty
-            else:
-                empty = False
-    if empty:
-        os.rmdir(path)
-    return empty
+def deleteEmptyFolders(path: str):
+    path = Path(path)
+    for dirpath, dirnames, filenames in os.walk(path, topdown=False):
+        for dirname in dirnames:
+            subdir = path / dirpath / dirname
+            with os.scandir(path) as it:
+                if not any(it):
+                    os.rmdir(subdir)


### PR DESCRIPTION
A couple changes to improve the performance of RootBuilders Sync/Clear operations. Some more details of the changes in the commit messages.

I have a sizable mod list, and also have the Creation Kit installed (which puts a large number of files in "Skyrim Special Edition\Data\Source\Scripts"), and RootBuilder was taking well over 10 seconds to perform the Clear action, despite the Data directory being excluded. After these updates, it now takes about 0.1 seconds.


Another thing I noticed was creating the cache after deleting it would freeze the gui for a second. It looks like this is because it's trying to load a json file that doesn't exist through common_utilities.py, which will retry for 1 second. I assume there's some reason for that, but maybe it could be removed for this case?