### PR TITLE
Add MO2 Oracle plugin

### DIFF
--- a/directory/plugin_directory.json
+++ b/directory/plugin_directory.json
@@ -118,5 +118,10 @@
     "Name": "BodySlide Batch Builder",
     "Identifier": "BatchBodySlideBuilder",
     "Manifest": "https://raw.githubusercontent.com/tkoopman/MO2-BodySlide-Batch-Builder/refs/heads/master/plugindefinition.json"
+  },
+  {
+    "Name": "Oracle",
+    "Identifier": "plugin_oracle",
+    "Manifest": "https://raw.githubusercontent.com/Levalicious/MO2-Oracle/refs/heads/master/plugin_definition.json"
   }
 ]


### PR DESCRIPTION
Hoping I did this right - is the Identifier the plugin path, or the result of IPlugin.name()? Or a completely unrelated identifier for Pluginfinder internally?
Thanks for providing this tool!