### PR TITLE
Add FOMOD Plus to plugin list

### DIFF
--- a/directory/plugin_directory.json
+++ b/directory/plugin_directory.json
@@ -123,5 +123,10 @@
     "Name": "Oracle",
     "Identifier": "plugin_oracle",
     "Manifest": "https://raw.githubusercontent.com/Levalicious/MO2-Oracle/refs/heads/master/plugin_definition.json"
+  },
+  {
+    "Name": "FOMOD Plus",
+    "Identifier": "fomod-plus",
+    "Manifest": "https://raw.githubusercontent.com/aglowinthefield/mo2-fomod-plus/refs/heads/main/plugindefinition.json"
   }
 ]


### PR DESCRIPTION
Add @aglowinthefield's FOMOD Plus plugin to the Plugin Finder.

Personally found it really useful. Bunch of features I wish were default, particularly re-selecting previously installed options on reinstall

Resolves #42