### PR TITLE
Add Nexus Collection Downloader to Plugin Finder list

### DIFF
--- a/directory/plugin_directory.json
+++ b/directory/plugin_directory.json
@@ -128,5 +128,10 @@
     "Name": "FOMOD Plus",
     "Identifier": "fomod-plus",
     "Manifest": "https://raw.githubusercontent.com/aglowinthefield/mo2-fomod-plus/refs/heads/main/plugindefinition.json"
+  },
+  {
+    "Name": "Nexus Collection Downloader",
+    "Identifier": "nxm-collection-dl",
+    "Manifest": "https://raw.githubusercontent.com/Furglitch/modorganizer2-nxm-collection-dl/main/plugindefinition.json"
   }
 ]


### PR DESCRIPTION
MO2 plugin that allows the download of Nexus' Collections.

Currently functional, though still working to implement a few features.